### PR TITLE
Move to .Net 5.0

### DIFF
--- a/Helpers/Options.cs
+++ b/Helpers/Options.cs
@@ -189,7 +189,8 @@ namespace xdelta3_cross_gui
                 this.ZipFilesWhenDone = json.ZipFilesWhenDone;
                 this.ShowTerminal = json.ShowTerminal;
 
-            } catch (Exception e)
+            }
+            catch (Exception e)
             {
                 Debug.WriteLine("Failed to load saved options\n" + e);
             }
@@ -249,7 +250,7 @@ namespace xdelta3_cross_gui
                 this.ZipName = "patch";
                 valid = false;
             }
-            
+
             return valid;
         }
 

--- a/Helpers/Options.cs
+++ b/Helpers/Options.cs
@@ -17,9 +17,7 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
-using System.IO.IsolatedStorage;
 using System.Runtime.CompilerServices;
-using static System.Environment;
 
 namespace xdelta3_cross_gui
 {

--- a/Localization/Localizer.cs
+++ b/Localization/Localizer.cs
@@ -1,15 +1,6 @@
-﻿using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Platform;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
-using System.Globalization;
-using System.IO;
-using System.Reflection;
 using System.Resources;
-using System.Text;
 
 namespace xdelta3_cross_gui.Localization
 {

--- a/Program.cs
+++ b/Program.cs
@@ -12,8 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.*/
 
-using System;
 using Avalonia;
+using System;
 
 namespace xdelta3_cross_gui
 {

--- a/Publish/Linux/Appimage.sh
+++ b/Publish/Linux/Appimage.sh
@@ -17,7 +17,6 @@ limitations under the License.
 
 ORIGIN="$(pwd)"
 cd "../.."
-#dotnet publish --configuration Release --framework netcoreapp3.1 -r linux-x64 --self-contained true /p:PublishTrimmed=true -o bin/Release/netcoreapp3.1/publishLinux
 dotnet publish -r linux-x64 -c Release -p:SelfContained=True -o bin/Release/net5.0/publishLinux
 cd "$ORIGIN"
 

--- a/Publish/Linux/Appimage.sh
+++ b/Publish/Linux/Appimage.sh
@@ -17,12 +17,13 @@ limitations under the License.
 
 ORIGIN="$(pwd)"
 cd "../.."
-dotnet publish --configuration Release --framework netcoreapp3.1 -r linux-x64 --self-contained true /p:PublishTrimmed=true -o bin/Release/netcoreapp3.1/publishLinux
+#dotnet publish --configuration Release --framework netcoreapp3.1 -r linux-x64 --self-contained true /p:PublishTrimmed=true -o bin/Release/netcoreapp3.1/publishLinux
+dotnet publish -r linux-x64 -c Release -o bin/Release/net5.0/publishLinux
 cd "$ORIGIN"
 
 APP_NAME="xDelta3 Cross GUI"
 APP_OUTPUT_PATH="Build"
-PUBLISH_OUTPUT_DIRECTORY="../../bin/Release/netcoreapp3.1/publishLinux/."
+PUBLISH_OUTPUT_DIRECTORY="../../bin/Release/net5.0/publishLinux/."
 APP_TAR_NAME1="xdelta3-cross-gui_"
 APP_TAR_NAME2="_linux_AppImage_x86_64"
 

--- a/Publish/Linux/Appimage.sh
+++ b/Publish/Linux/Appimage.sh
@@ -18,7 +18,7 @@ limitations under the License.
 ORIGIN="$(pwd)"
 cd "../.."
 #dotnet publish --configuration Release --framework netcoreapp3.1 -r linux-x64 --self-contained true /p:PublishTrimmed=true -o bin/Release/netcoreapp3.1/publishLinux
-dotnet publish -r linux-x64 -c Release -o bin/Release/net5.0/publishLinux
+dotnet publish -r linux-x64 -c Release -p:SelfContained=True -o bin/Release/net5.0/publishLinux
 cd "$ORIGIN"
 
 APP_NAME="xDelta3 Cross GUI"

--- a/Publish/Linux/LooseLinux.sh
+++ b/Publish/Linux/LooseLinux.sh
@@ -17,12 +17,12 @@ limitations under the License.
 
 ORIGIN="$(pwd)"
 cd "../.."
-dotnet publish --configuration Release --framework netcoreapp3.1 -r linux-x64 --self-contained true /p:PublishTrimmed=true -o bin/Release/netcoreapp3.1/publishLinux
+dotnet publish -r linux-x64 -c Release -p:SelfContained=True -o bin/Release/net5.0/publishLinux
 cd "$ORIGIN"
 
 APP_NAME="xDelta3 Cross GUI"
 APP_OUTPUT_PATH="Build"
-PUBLISH_OUTPUT_DIRECTORY="../../bin/Release/netcoreapp3.1/publishLinux/."
+PUBLISH_OUTPUT_DIRECTORY="../../bin/Release/net5.0/publishLinux/."
 APP_TAR_NAME1="xdelta3-cross-gui_"
 APP_TAR_NAME2="_linux_x86_64"
 

--- a/Publish/MacOS/MacOS.sh
+++ b/Publish/MacOS/MacOS.sh
@@ -17,7 +17,6 @@ limitations under the License.
 
 ORIGIN="$(pwd)"
 cd "../.."
-#dotnet publish --configuration Release --framework netcoreapp3.1 -r osx-x64 --self-contained true /p:PublishTrimmed=true -o bin/Release/netcoreapp3.1/publishMac
 dotnet publish -r osx-x64 -c Release -p:SelfContained=True -o bin/Release/net5.0/publishMac
 cd "$ORIGIN"
 

--- a/Publish/MacOS/MacOS.sh
+++ b/Publish/MacOS/MacOS.sh
@@ -17,14 +17,15 @@ limitations under the License.
 
 ORIGIN="$(pwd)"
 cd "../.."
-dotnet publish --configuration Release --framework netcoreapp3.1 -r osx-x64 --self-contained true /p:PublishTrimmed=true -o bin/Release/netcoreapp3.1/publishMac
+#dotnet publish --configuration Release --framework netcoreapp3.1 -r osx-x64 --self-contained true /p:PublishTrimmed=true -o bin/Release/netcoreapp3.1/publishMac
+dotnet publish -r osx-x64 -c Release -o bin/Release/net5.0/publishMac
 cd "$ORIGIN"
 
 APP_NAME="xDelta3 Cross GUI.app"
 APP_OUTPUT_PATH="Output"
 APP_TAR_NAME1="xdelta3-cross-gui_"
 APP_TAR_NAME2="_macOS_x86_64"
-PUBLISH_OUTPUT_DIRECTORY="../../bin/Release/netcoreapp3.1/publishMac/."
+PUBLISH_OUTPUT_DIRECTORY="../../bin/Release/net5.0/publishMac/."
 INFO_PLIST="Info.plist"
 ICON_FILE="Icon.icns"
 

--- a/Publish/MacOS/MacOS.sh
+++ b/Publish/MacOS/MacOS.sh
@@ -18,7 +18,7 @@ limitations under the License.
 ORIGIN="$(pwd)"
 cd "../.."
 #dotnet publish --configuration Release --framework netcoreapp3.1 -r osx-x64 --self-contained true /p:PublishTrimmed=true -o bin/Release/netcoreapp3.1/publishMac
-dotnet publish -r osx-x64 -c Release -o bin/Release/net5.0/publishMac
+dotnet publish -r osx-x64 -c Release -p:SelfContained=True -o bin/Release/net5.0/publishMac
 cd "$ORIGIN"
 
 APP_NAME="xDelta3 Cross GUI.app"

--- a/Publish/Windows/Windows.sh
+++ b/Publish/Windows/Windows.sh
@@ -17,7 +17,6 @@ limitations under the License.
 
 ORIGIN="$(pwd)"
 cd "../.."
-#dotnet publish -c Release --framework net5.0 -r win-x86 --self-contained true -p:CopyOutputSymbolsToPublishDirectory=False -p:PublishTrimmed=True -p:TrimMode=Link -p:PublishSingleFile=True -p:IncludeAllContentForSelfExtract=True -o bin/Release/net5.0/publishWin
 #dotnet publish -r win-x86 -c Release -p:SelfContained=True -p:IncludeAllContentForSelfExtract=True -p:PublishSingleFile=True -o bin/Release/net5.0/publishWin
 cd "$ORIGIN"
 

--- a/Publish/Windows/Windows.sh
+++ b/Publish/Windows/Windows.sh
@@ -17,12 +17,13 @@ limitations under the License.
 
 ORIGIN="$(pwd)"
 cd "../.."
-dotnet publish --configuration Release --framework netcoreapp3.1 -r win-x86 --self-contained true /p:CopyOutputSymbolsToPublishDirectory=false /p:PublishTrimmed=true -p:PublishSingleFile=true -o bin/Release/netcoreapp3.1/publishWin
+#dotnet publish -c Release --framework net5.0 -r win-x86 --self-contained true -p:CopyOutputSymbolsToPublishDirectory=False -p:PublishTrimmed=True -p:TrimMode=Link -p:PublishSingleFile=True -p:IncludeAllContentForSelfExtract=True -o bin/Release/net5.0/publishWin
+dotnet publish -r win-x86 -c Release -o bin/Release/net5.0/publishWin
 cd "$ORIGIN"
 
 APP_NAME="xDelta3 Cross GUI"
 APP_OUTPUT_PATH="Build"
-PUBLISH_OUTPUT_DIRECTORY="../../bin/Release/netcoreapp3.1/publishWin/."
+PUBLISH_OUTPUT_DIRECTORY="../../bin/Release/net5.0/publishWin/."
 APP_TAR_NAME1="xdelta3-cross-gui_"
 APP_TAR_NAME2="_win_x86"
 

--- a/Publish/Windows/Windows.sh
+++ b/Publish/Windows/Windows.sh
@@ -18,7 +18,7 @@ limitations under the License.
 ORIGIN="$(pwd)"
 cd "../.."
 #dotnet publish -c Release --framework net5.0 -r win-x86 --self-contained true -p:CopyOutputSymbolsToPublishDirectory=False -p:PublishTrimmed=True -p:TrimMode=Link -p:PublishSingleFile=True -p:IncludeAllContentForSelfExtract=True -o bin/Release/net5.0/publishWin
-dotnet publish -r win-x86 -c Release -o bin/Release/net5.0/publishWin
+#dotnet publish -r win-x86 -c Release -p:SelfContained=True -p:IncludeAllContentForSelfExtract=True -p:PublishSingleFile=True -o bin/Release/net5.0/publishWin
 cd "$ORIGIN"
 
 APP_NAME="xDelta3 Cross GUI"

--- a/Windows/Components/PathFileComponent.axaml.cs
+++ b/Windows/Components/PathFileComponent.axaml.cs
@@ -34,7 +34,8 @@ namespace xdelta3_cross_gui
         private MainWindow.FileCategory _FileCategory;
 
         private bool _IsSelected = false;
-        public bool IsSelected {
+        public bool IsSelected
+        {
             get => _IsSelected;
             set
             {
@@ -54,7 +55,7 @@ namespace xdelta3_cross_gui
         {
             this.InitializeComponent();
         }
-        public PathFileComponent(MainWindow parent,  string url, int index, MainWindow.FileCategory fileCategory)
+        public PathFileComponent(MainWindow parent, string url, int index, MainWindow.FileCategory fileCategory)
         {
             this.InitializeComponent();
 

--- a/Windows/MainWindow.axaml.cs
+++ b/Windows/MainWindow.axaml.cs
@@ -393,7 +393,10 @@ namespace xdelta3_cross_gui
             try
             {
                 string url = await this.OpenFolderBrowser();
-                this.Options.PatchFileDestination = url;
+                if (url != "")
+                {
+                    this.Options.PatchFileDestination = url;
+                }
             }
             catch (Exception e)
             {

--- a/xdelta3_cross_gui.csproj
+++ b/xdelta3_cross_gui.csproj
@@ -1,12 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifiers>win-x86;win-x64;osx-x64;linux-x64;</RuntimeIdentifiers>
     <Authors>dan0v</Authors>
     <Description>A cross-platform graphical user interface for xDelta3 patching</Description>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
     <Version>1.0.9</Version>
+    <SelfContained>true</SelfContained>
+    <CopyOutputSymbolsToPublishDirectory>true</CopyOutputSymbolsToPublishDirectory>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>Link</TrimMode>
+    <PublishSingleFile>true</PublishSingleFile>
+    <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Assets\exec\xdelta3_mac" />
@@ -37,7 +43,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="0.10.0" />
     <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Localization\Language.Designer.cs">

--- a/xdelta3_cross_gui.csproj
+++ b/xdelta3_cross_gui.csproj
@@ -6,13 +6,10 @@
     <Authors>dan0v</Authors>
     <Description>A cross-platform graphical user interface for xDelta3 patching</Description>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>1.0.9</Version>
-    <SelfContained>true</SelfContained>
-    <CopyOutputSymbolsToPublishDirectory>true</CopyOutputSymbolsToPublishDirectory>
+    <Version>1.1.0</Version>
+    <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>Link</TrimMode>
-    <PublishSingleFile>true</PublishSingleFile>
-    <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Assets\exec\xdelta3_mac" />


### PR DESCRIPTION
- Changed .Net version to 5.0
- Smaller published application size (`TrimMode=Link`)
- Updated and simplified publish scripts
- Organized imports
- Bumped Newtonsoft.Json version